### PR TITLE
feat/#16: 로그아웃 및 회원 탈퇴 구현

### DIFF
--- a/src/main/java/kr/omong/todagtodag/domain/relation/repository/UserRelationRepository.java
+++ b/src/main/java/kr/omong/todagtodag/domain/relation/repository/UserRelationRepository.java
@@ -9,4 +9,6 @@ public interface UserRelationRepository extends JpaRepository<UserRelation, Long
     boolean existsByTodakIdAndSungjangId(Long toakId, Long sungjangId);
 
     Optional<UserRelation> findBySungjangId(Long sungjangId);
+
+    void deleteAllByTodakIdOrSungjangId(Long todakId, Long sungjangId);
 }

--- a/src/main/java/kr/omong/todagtodag/domain/user/controller/UserOnboardingController.java
+++ b/src/main/java/kr/omong/todagtodag/domain/user/controller/UserOnboardingController.java
@@ -10,6 +10,7 @@ import kr.omong.todagtodag.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
-@Tag(name = "유저 온보딩 API", description = "신규 유저의 역할별 온보딩을 처리합니다.")
-public class UserOnBoardingController {
+@Tag(name = "유저 API", description = "유저 온보딩, 로그아웃, 회원 탈퇴를 처리합니다.")
+public class UserOnboardingController {
 
     private final UserService userService;
 
@@ -45,5 +46,26 @@ public class UserOnBoardingController {
             @Valid @RequestBody SungjangOnboardingRequest request
     ) {
         return ResponseEntity.ok(userService.onboardSungjang(userId, request));
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "클라이언트에서 accessToken을 삭제하여 로그아웃 처리합니다."
+    )
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인된 사용자의 계정을 삭제합니다."
+    )
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal Long userId
+    ) {
+        userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kr/omong/todagtodag/domain/user/repository/SungjangProfileRepository.java
+++ b/src/main/java/kr/omong/todagtodag/domain/user/repository/SungjangProfileRepository.java
@@ -4,4 +4,5 @@ import kr.omong.todagtodag.domain.user.entity.SungjangProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SungjangProfileRepository extends JpaRepository<SungjangProfile, Long> {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/kr/omong/todagtodag/domain/user/service/UserService.java
+++ b/src/main/java/kr/omong/todagtodag/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import kr.omong.todagtodag.domain.auth.dto.AuthResponse;
 import kr.omong.todagtodag.domain.auth.exception.AuthErrorCode;
 import kr.omong.todagtodag.domain.auth.exception.AuthException;
 import kr.omong.todagtodag.domain.auth.jwt.JwtTokenProvider;
+import kr.omong.todagtodag.domain.relation.repository.UserRelationRepository;
 import kr.omong.todagtodag.domain.relation.service.RelationService;
 import kr.omong.todagtodag.domain.user.dto.SungjangOnboardingRequest;
 import kr.omong.todagtodag.domain.user.dto.TodakOnboardingRequest;
@@ -23,6 +24,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final RelationService relationService;
     private final SungjangProfileRepository sungjangProfileRepository;
+    private final UserRelationRepository userRelationRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -66,6 +68,14 @@ public class UserService {
                         .build()
         );
         return buildAuthResponse(user);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = getById(userId);
+        sungjangProfileRepository.deleteByUserId(userId);
+        userRelationRepository.deleteAllByTodakIdOrSungjangId(userId, userId);
+        userRepository.delete(user);
     }
 
     private User updateRoleForPendingUser(Long userId, Role role) {


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현 및 수정
- [ ] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [x] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
로그아웃, 회원 탈퇴 로직 구현했습니다
## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 👉 해당 이슈
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- closed #16 마이페이지

# 로그아웃 / 회원탈퇴 API 테스트 가이드

## 1. 사전 준비

- 서버를 실행한다.
- 로그인 API를 통해 `accessToken`을 발급받는다.
- 인증이 필요한 요청이므로 `Authorization: Bearer {accessToken}` 헤더를 사용한다.

예시:

```http
Authorization: Bearer eyJhbGciOi...
```

## 2. 로그아웃 API 테스트

### 엔드포인트

```http
POST /users/logout
```

### 설명

- JWT Access Token 기반이므로 서버에서 토큰을 폐기하지 않는다.
- 서버는 단순히 `200 OK`만 반환한다.
- 실제 로그아웃 처리는 클라이언트에서 토큰을 삭제하는 방식으로 확인한다.

### curl 예시

```bash
curl -i -X POST http://localhost:8080/users/logout \
  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
```

### 기대 결과

- 상태코드: `200 OK`
- 응답 바디: 없음

## 3. 회원탈퇴 API 테스트

### 엔드포인트

```http
DELETE /users/withdraw
```

### 설명

- 현재 로그인한 사용자를 삭제한다.
- 사용자 삭제 전에 연관된 프로필과 관계 데이터도 함께 정리된다.
- 성공 시 `204 No Content`를 반환한다.

### curl 예시 1

```bash
curl -i -X DELETE http://localhost:8080/users \
  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
```

### curl 예시 2

```bash
curl -i -X DELETE http://localhost:8080/users/withdraw \
  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
```

### 기대 결과

- 상태코드: `204 No Content`
- 응답 바디: 없음

## 4. 회원탈퇴 이후 확인 방법

### 4.1 보호된 API 재호출

- 탈퇴에 사용한 동일한 토큰으로 다른 인증 API를 호출한다.
- 정상이라면 사용자 조회 실패 또는 인증 실패 응답이 발생해야 한다.

### 4.2 데이터베이스 확인

아래 데이터가 삭제되었는지 확인한다.

- `users`
- `sungjang_profile`
- `user_relation`

예시 SQL:

```sql
select * from users where id = {userId};
select * from sungjang_profile where user_id = {userId};
select * from user_relation where todak_id = {userId} or sungjang_id = {userId};
```

## 5. Swagger로 테스트하는 방법

- Swagger UI에 접속한다.
- 우측 상단 `Authorize` 버튼에 Bearer 토큰을 입력한다.
- 아래 API를 실행한다.

```text
POST   /users/logout
DELETE /users/withdraw
```

## 6. 체크 포인트

- 로그아웃은 서버 상태 변화가 없어야 한다.
- 로그아웃 응답은 `200 OK`여야 한다.
- 회원탈퇴 응답은 `204 No Content`여야 한다.
- 회원탈퇴 후 사용자 및 연관 데이터가 실제로 삭제되어야 한다.
