### PR TITLE
fix/#39: [긴급] Refresh Token 발급 정책에 의한 ms단위의 무한 로깅 문제

### DIFF
--- a/src/main/java/kr/omong/todagtodag/TodagtodagApplication.java
+++ b/src/main/java/kr/omong/todagtodag/TodagtodagApplication.java
@@ -2,8 +2,10 @@ package kr.omong.todagtodag;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TodagtodagApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/omong/todagtodag/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/entity/RefreshToken.java
@@ -42,7 +42,15 @@ public class RefreshToken {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isRevoked = false;
+
     public boolean isExpired(LocalDateTime now) {
-        return expiryDate.isBefore(now);
+        return !expiryDate.isAfter(now);
+    }
+
+    public void revoke() {
+        isRevoked = true;
     }
 }

--- a/src/main/java/kr/omong/todagtodag/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/repository/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByToken(String token);
 
     void deleteAllByUser(User user);
+
+    void deleteByIsRevokedTrue();
 }

--- a/src/main/java/kr/omong/todagtodag/domain/auth/scheduler/RefreshTokenSchedular.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/scheduler/RefreshTokenSchedular.java
@@ -1,0 +1,20 @@
+package kr.omong.todagtodag.domain.auth.scheduler;
+
+import kr.omong.todagtodag.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenSchedular {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 2 * * *")
+    public void deleteRevokedTokens() {
+        refreshTokenRepository.deleteByIsRevokedTrue();
+    }
+}

--- a/src/main/java/kr/omong/todagtodag/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/service/AuthService.java
@@ -35,7 +35,6 @@ public class AuthService {
     @Transactional
     public AuthResponse issueTokens(User user, boolean isNewUser) {
         LocalDateTime now = LocalDateTime.now();
-        String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = refreshTokenGenerator.createRefreshToken();
         LocalDateTime expiryDate = now.plus(Duration.ofMillis(jwtProperties.refreshTokenExpirationMillSecond()));
 
@@ -46,25 +45,22 @@ public class AuthService {
                 .createdAt(now)
                 .build());
 
-        return AuthResponse.builder()
-                .isNewUser(isNewUser)
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .role(user.getRole())
-                .build();
+        return createAuthResponse(user, isNewUser, refreshToken);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = AuthException.class)
     public AuthResponse refresh(String requestToken) {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(requestToken)
                 .orElseThrow(() -> new AuthException(ErrorCode.REFRESH_TOKEN_INVALID));
+        validateRevoked(refreshToken);
+        LocalDateTime now = LocalDateTime.now();
 
-        if (refreshToken.isExpired(LocalDateTime.now())) {
+        if (refreshToken.isExpired(now)) {
             refreshTokenRepository.delete(refreshToken);
             throw new AuthException(ErrorCode.REFRESH_TOKEN_EXPIRED);
         }
 
-        refreshTokenRepository.delete(refreshToken);
+        refreshToken.revoke();
         return issueTokens(refreshToken.getUser(), false);
     }
 
@@ -73,6 +69,7 @@ public class AuthService {
         User user = getAuthenticatedUser(userId);
         RefreshToken refreshToken = refreshTokenRepository.findByToken(requestToken)
                 .orElseThrow(() -> new AuthException(ErrorCode.REFRESH_TOKEN_INVALID));
+        validateRevoked(refreshToken);
 
         if (!refreshToken.getUser().getId().equals(user.getId())) {
             throw new AuthException(ErrorCode.REFRESH_TOKEN_INVALID);
@@ -110,5 +107,20 @@ public class AuthService {
         }
         return userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private AuthResponse createAuthResponse(User user, boolean isNewUser, String refreshToken) {
+        return AuthResponse.builder()
+                .isNewUser(isNewUser)
+                .accessToken(jwtTokenProvider.createAccessToken(user))
+                .refreshToken(refreshToken)
+                .role(user.getRole())
+                .build();
+    }
+
+    private void validateRevoked(RefreshToken refreshToken) {
+        if (refreshToken.isRevoked()) {
+            throw new AuthException(ErrorCode.REFRESH_TOKEN_REVOKED);
+        }
     }
 }

--- a/src/main/java/kr/omong/todagtodag/global/exception/ErrorCode.java
+++ b/src/main/java/kr/omong/todagtodag/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Access Token이 만료되었습니다."),
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh Token이 만료되었습니다."),
+    REFRESH_TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "폐기되어 사용할 수 없는 Refresh Token입니다."),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요."),
 
     // Relation

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -10,7 +10,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         show_sql: true
         jdbc:
           time_zone: Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         show_sql: true
         jdbc:
           time_zone: Asia/Seoul

--- a/src/test/java/kr/omong/todagtodag/domain/auth/AuthRefreshTokenRotationTest.java
+++ b/src/test/java/kr/omong/todagtodag/domain/auth/AuthRefreshTokenRotationTest.java
@@ -1,0 +1,181 @@
+package kr.omong.todagtodag.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import kr.omong.todagtodag.domain.auth.entity.RefreshToken;
+import kr.omong.todagtodag.domain.auth.repository.RefreshTokenRepository;
+import kr.omong.todagtodag.domain.auth.scheduler.RefreshTokenSchedular;
+import kr.omong.todagtodag.domain.user.entity.Role;
+import kr.omong.todagtodag.domain.user.entity.User;
+import kr.omong.todagtodag.domain.user.repository.UserRepository;
+import kr.omong.todagtodag.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = {
+        "app.jwt.secret=01234567890123456789012345678901",
+        "app.jwt.access-token-expiration-mill-second=86400000",
+        "app.jwt.refresh-token-expiration-mill-second=1209600000",
+        "app.oauth.apple.client-id=test-client-id"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class AuthRefreshTokenRotationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private RefreshTokenSchedular refreshTokenSchedular;
+
+    @Test
+    void pendingUserCanRefreshButPreviousRefreshTokenIsRevokedAndCannotBeReused() throws Exception {
+        JsonNode pendingUser = createTestUser("rtr-pending-" + UUID.randomUUID());
+        String firstAccessToken = pendingUser.get("accessToken").asText();
+        String firstRefreshToken = pendingUser.get("refreshToken").asText();
+
+        JsonNode refreshed = refresh(firstRefreshToken);
+        String secondRefreshToken = refreshed.get("refreshToken").asText();
+
+        assertThat(refreshed.get("role").asText()).isEqualTo(Role.PENDING.name());
+        assertThat(secondRefreshToken).isNotEqualTo(firstRefreshToken);
+        assertThat(refreshTokenRepository.findByToken(firstRefreshToken)).hasValueSatisfying(
+                refreshToken -> assertThat(refreshToken.isRevoked()).isTrue()
+        );
+        assertThat(refreshTokenRepository.findByToken(secondRefreshToken)).hasValueSatisfying(
+                refreshToken -> assertThat(refreshToken.isRevoked()).isFalse()
+        );
+
+        refreshExpectError(firstRefreshToken, ErrorCode.REFRESH_TOKEN_REVOKED);
+        logoutExpectError(firstAccessToken, firstRefreshToken, ErrorCode.REFRESH_TOKEN_REVOKED);
+
+        logout(refreshed.get("accessToken").asText(), secondRefreshToken);
+        assertThat(refreshTokenRepository.findByToken(secondRefreshToken)).isEmpty();
+    }
+
+    @Test
+    void expiredRefreshTokenIsRejectedAndDeleted() throws Exception {
+        User user = userRepository.save(User.builder()
+                .providerId("rtr-expired-" + UUID.randomUUID())
+                .role(Role.PENDING)
+                .build());
+        String expiredToken = "expired-refresh-token-" + UUID.randomUUID();
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(expiredToken)
+                .expiryDate(LocalDateTime.now().minusSeconds(1))
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .build());
+
+        refreshExpectError(expiredToken, ErrorCode.REFRESH_TOKEN_EXPIRED);
+
+        assertThat(refreshTokenRepository.findByToken(expiredToken)).isEmpty();
+    }
+
+    @Test
+    void schedulerDeletesOnlyRevokedRefreshTokens() {
+        User user = userRepository.save(User.builder()
+                .providerId("rtr-scheduler-" + UUID.randomUUID())
+                .role(Role.PENDING)
+                .build());
+        LocalDateTime now = LocalDateTime.now();
+        String revokedToken = "revoked-refresh-token-" + UUID.randomUUID();
+        String activeToken = "active-refresh-token-" + UUID.randomUUID();
+        RefreshToken revoked = RefreshToken.builder()
+                .user(user)
+                .token(revokedToken)
+                .expiryDate(now.plusDays(1))
+                .createdAt(now)
+                .build();
+        revoked.revoke();
+        refreshTokenRepository.save(revoked);
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(activeToken)
+                .expiryDate(now.plusDays(1))
+                .createdAt(now)
+                .build());
+
+        refreshTokenSchedular.deleteRevokedTokens();
+
+        assertThat(refreshTokenRepository.findByToken(revokedToken)).isEmpty();
+        assertThat(refreshTokenRepository.findByToken(activeToken)).isPresent();
+    }
+
+    private JsonNode createTestUser(String providerId) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/test/test-user")
+                        .param("providerId", providerId))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private JsonNode refresh(String refreshToken) throws Exception {
+        MvcResult result = mockMvc.perform(post("/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshRequest(refreshToken)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private void refreshExpectError(String refreshToken, ErrorCode errorCode) throws Exception {
+        mockMvc.perform(post("/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshRequest(refreshToken)))
+                .andExpect(status().is(errorCode.getStatus().value()))
+                .andExpect(jsonPath("$.code").value(errorCode.name()));
+    }
+
+    private void logout(String accessToken, String refreshToken) throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshRequest(refreshToken)))
+                .andExpect(status().isOk());
+    }
+
+    private void logoutExpectError(String accessToken, String refreshToken, ErrorCode errorCode) throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshRequest(refreshToken)))
+                .andExpect(status().is(errorCode.getStatus().value()))
+                .andExpect(jsonPath("$.code").value(errorCode.name()));
+    }
+
+    private String refreshRequest(String refreshToken) {
+        return """
+                {
+                  "refreshToken": "%s"
+                }
+                """.formatted(refreshToken);
+    }
+
+    private String bearer(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+}

--- a/src/test/java/kr/omong/todagtodag/domain/sticker/StickerBoardFlowTest.java
+++ b/src/test/java/kr/omong/todagtodag/domain/sticker/StickerBoardFlowTest.java
@@ -56,8 +56,13 @@ class StickerBoardFlowTest {
         assertThat(onboardTodak.get("accessToken").asText()).isNotBlank();
         assertThat(onboardTodak.get("role").asText()).isEqualTo(Role.TODAK.name());
 
-        JsonNode onboardedSungjangUser = createTestUser(sungjangProviderId);
+        JsonNode onboardedSungjangUser = refresh(sungjangUser.get("refreshToken").asText());
         assertThat(onboardedSungjangUser.get("role").asText()).isEqualTo(Role.SUNGJANG.name());
+        assertThat(onboardedSungjangUser.get("refreshToken").asText())
+                .isNotEqualTo(sungjangUser.get("refreshToken").asText());
+        JsonNode repeatedRefresh = refresh(onboardedSungjangUser.get("refreshToken").asText());
+        assertThat(repeatedRefresh.get("refreshToken").asText())
+                .isNotEqualTo(onboardedSungjangUser.get("refreshToken").asText());
         String sungjangAccessToken = onboardedSungjangUser.get("accessToken").asText();
         String todakAccessToken = onboardTodak.get("accessToken").asText();
         JsonNode relations = getTodakRelations(todakAccessToken);
@@ -148,6 +153,19 @@ class StickerBoardFlowTest {
                                   "inviteCode": "%s"
                                 }
                                 """.formatted(inviteCode)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private JsonNode refresh(String refreshToken) throws Exception {
+        MvcResult result = mockMvc.perform(post("/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "%s"
+                                }
+                                """.formatted(refreshToken)))
                 .andExpect(status().isOk())
                 .andReturn();
         return objectMapper.readTree(result.getResponse().getContentAsString());


### PR DESCRIPTION
[긴급] Refresh Token 발급 정책에 의한 ms단위의 무한 로깅 문제
프론트 온보딩/토큰 갱신 흐름에서 refresh API가 반복 호출되며 서버에서 refresh token 조회, 생성, 삭제 쿼리가 
짧은 주기로 계속 발생되는 문제를 해결했습니다..

📢 변경 사항
• Refresh Token Rotation 정책은 유지하되, 기존 refresh token을 즉시 삭제하지 않고 revoked 상태로 변경하도록 수정했습니다.
• 폐기된 refresh token은 스케줄러를 통해 주기적으로 삭제되도록 추가했습니다.
• 이미 revoked 상태인 refresh token으로 refresh 또는 logout을 요청하면 REFRESH_TOKEN_REVOKED 예외가 발생하도록 처리했습니다.
• 만료된 refresh token 요청 시 삭제 처리가 롤백되지 않도록 트랜잭션 설정을 보강했습니다.
• 스케줄러의 revoked token 삭제 작업에 트랜잭션을 적용했습니다.
• Hibernate format_sql 설정을 false로 변경했습니다.
• RTR 관련 테스트코드를 작성하였습니다.
◦ PENDING 유저 refresh
◦ 이전 refresh token 재사용 차단
◦ revoked token logout 차단
◦ 만료 refresh token 삭제
◦ 스케줄러의 revoked token 삭제 검증
❗️To Reviewer
기존 refresh token은 새 token 발급 시 revoked 처리되고, 이후 재사용하면 REFRESH_TOKEN_REVOKED로 거부됩니다.
엔드포인트 추가나 인증 응답 필드 변경은 없습니다.

👉 해당 이슈
• closed #39