### PR TITLE
Fix/#41 동시에 `HttpMessageNotReadableException` 예외를 처리하던 문제를 해결

### DIFF
--- a/src/main/java/kr/omong/todagtodag/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/omong/todagtodag/global/exception/GlobalExceptionHandler.java
@@ -68,11 +68,6 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<?> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
-        return ResponseEntity.badRequest().body("잘못된 요청 값입니다.");
-    }
-
     private boolean isLocalDateFormatException(HttpMessageNotReadableException exception) {
         Throwable cause = exception.getCause();
         while (cause != null) {


### PR DESCRIPTION
…ion` 예외를 처리하던 문제를 해결

## 📝 PR 타입
- [ ] 기능 구현 및 수정
- [x] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->

Handler에서 동시에 `HttpMessageNotReadableException` 예외를 처리하던 문제를 해결하였습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 👉 해당 이슈
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- closed #41
