### PR TITLE
fix/#41: 토큰 refresh 시에 revoke 상태만 만들도록 수정

### DIFF
--- a/src/main/java/kr/omong/todagtodag/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/entity/RefreshToken.java
@@ -46,9 +46,9 @@ public class RefreshToken {
     @Column(nullable = false)
     private boolean isRevoked = false;
 
-    public boolean isExpired(LocalDateTime now) {
-        return !expiryDate.isAfter(now);
-    }
+//    public boolean isExpired(LocalDateTime now) {
+//        return !expiryDate.isAfter(now);
+//    }
 
     public void revoke() {
         isRevoked = true;

--- a/src/main/java/kr/omong/todagtodag/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/omong/todagtodag/domain/auth/service/AuthService.java
@@ -53,12 +53,12 @@ public class AuthService {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(requestToken)
                 .orElseThrow(() -> new AuthException(ErrorCode.REFRESH_TOKEN_INVALID));
         validateRevoked(refreshToken);
-        LocalDateTime now = LocalDateTime.now();
-
-        if (refreshToken.isExpired(now)) {
-            refreshTokenRepository.delete(refreshToken);
-            throw new AuthException(ErrorCode.REFRESH_TOKEN_EXPIRED);
-        }
+//        LocalDateTime now = LocalDateTime.now();
+//
+//        if (refreshToken.isExpired(now)) {
+//            refreshTokenRepository.delete(refreshToken);
+//            throw new AuthException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+//        }
 
         refreshToken.revoke();
         return issueTokens(refreshToken.getUser(), false);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현 및 수정
- [x] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->

#40 으로도 고쳐지지 않은 문제로,
토큰 refresh 시에 토큰의 상태를 revoke로 변경 후, 삭제하지 않도록 합니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 👉 해당 이슈
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- closed #39 
